### PR TITLE
Allow report generation on watchified updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,15 @@ function instrument(options) {
   return transform;
 }
 
+var report = [];
+
 function writeReports(options) {
   var collector = new Istanbul.Collector();
-  var report = options.report || [];
-  delete(options.report);
+
+  if (options.report) {
+    report = options.report;
+    delete(options.report);
+  }
 
   var data = '';
   return through(function(buf, enc, next) {
@@ -74,6 +79,11 @@ function writeReports(options) {
 module.exports = function (b, opts) {
   var reporterOptions = _.omit(opts, 'exclude');
 
+  function apply() {
+    b.pipeline.get('wrap').push(writeReports(reporterOptions));
+  }
+
   b.transform(instrument(opts));
-  b.pipeline.get('wrap').push(writeReports(reporterOptions));
+  apply();
+  b.on('reset', apply);
 };


### PR DESCRIPTION
From [this issue](https://github.com/ferlores/mochify-istanbul/issues/10). This should allow coverage reports to be re-generated each time watchified tests are run.

Two simple changes:
1. Push `writeReports` onto the wrap stream each time the bundle is reset.
2. Store the array of reports outside the scope of `writeReports` so it retains the values across resets.

I'm pretty new to Github etiquette and extremely open to feedback! Thank you.