### PR TITLE
[minor] only add after hook once to allow correct processing of mulitple files

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var fs = require('fs');
 var path = require('path');
@@ -69,6 +70,21 @@ describe('Basic', function () {
 
       assert.equal(keys.length, 1, 'more than one file instrumented');
       assert.equal(path.basename(keys[0]), 'pass-100.js', 'wrong file instrumented');
+      done();
+    }));
+  });
+
+  it('should instrument multiple files and only expose coverage once', function (done) {
+    createTestInstance('./test/fixtures/pass-50.js ./test/fixtures/pass-100.js', {
+      report: ['json', 'cobertura']
+    }).bundle(validateOutput(function (report) {
+      var keys = Object.keys(report);
+
+      assert.equal(keys.length, 2, 'more than one file instrumented');
+      assert.equal(path.basename(keys[0]), 'pass-50.js', 'wrong file instrumented');
+      assert.equal(path.basename(keys[1]), 'pass-100.js', 'wrong file instrumented');
+      assert.equal(JSON.stringify(report[keys[0]].s), '{"1":1,"2":1,"3":1,"4":0}', 'not 50% coverage');
+      assert.equal(JSON.stringify(report[keys[1]].s), '{"1":1,"2":1,"3":1}', 'not 100% coverage');
       done();
     }));
   });


### PR DESCRIPTION
Allows processing of multiple files, it seems that the transform instrumenter would add multiple after hooks. Where only the first hook would output the correct coverage information, all others lacked coverage from subsequent files.

Couldn't find a neat stream to hook into, e.g. `end` event or similar, so just opted for a flag.