### PR TITLE
Parse coverage lines with Windows line breaks correctly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function writeReports(options) {
     data += buf;
     next();
   }, function(next) {
-    var re = /__coverage__='([^;]*)';\n/gi,
+    var re = /__coverage__='([^;]*)';(\r\n?|\n)/gi,
         match;
 
     // capture all the matches, there might be multiple


### PR DESCRIPTION
When using mochify-istanbul in Windows, the coverage lines are just dumped on the console obscuring test output, and no coverage is reported. This issue is covered by existing tests. Without the fix, all tests fail on Windows with npm test. 