### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
   },
   "homepage": "https://github.com/ferlores/mochify-istanbul",
   "dependencies": {
-    "istanbul": "^0.3.2",
+    "istanbul": "^0.4.2",
     "lodash": "^2.4.1",
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.0",
     "resolve": "^1.1.6",
-    "through2": "^0.6.3"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
-    "assert": "^1.1.2",
     "babel-istanbul": "^0.5.9",
     "babel-preset-es2015": "^6.3.13",
     "babelify": "^7.2.0",


### PR DESCRIPTION
I looked through all the changes carefully and couldn't find anything that is semantically breaking for us. I did a Mochify release with streams 3 based on Browserify 13 as well. It would be nice to have the same version of streams everywhere.

Also removed `assert` as it's implicitly added through Browserify.

I think this can go out as a minor.