### PR TITLE
fix exit without any report when tests fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var os = require('os');
 var resolve = require('resolve');
 var through = require('through2');
 var minimatch = require('minimatch');

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var os = require('os');
 var resolve = require('resolve');
 var through = require('through2');
 var minimatch = require('minimatch');
-var combine = require('stream-combiner');
-var split = require('split');
+var combine = require('stream-combiner2');
+var split = require('split2');
 var _ = require('lodash');
 
 function filterFiles(options, files) {

--- a/index.js
+++ b/index.js
@@ -64,18 +64,16 @@ function writeReports(options) {
   }
 
   var data = '';
-  var coverageRe = /__coverage__='([^;]*)'/gi;
+  var coverageRe = /__coverage__='([^;]*)';(\r\n?|\n)/gi;
   var extractCoverage = through(function(buf, enc, next) {
     data += buf;
     if (!coverageRe.test(buf.toString())) {
       this.push(buf);
-      this.push(os.EOL);
     }
     next();
   }, function(next) {
     var re = /__coverage__='([^;]*)';(\r\n?|\n)/gi;
     var match;
-
     // capture all the matches, there might be multiple
     while (match = re.exec(data)) {
       // match[1] contains JSON.stringify(__coverage__)
@@ -88,10 +86,9 @@ function writeReports(options) {
         .create(reportType, _.clone(options))
         .writeReport(collector, true);
     });
-
     next();
   });
-  return combine(split(), extractCoverage);
+  return combine(split(/(\r?\n)/), extractCoverage);
 }
 
 module.exports = function (b, opts) {

--- a/index.js
+++ b/index.js
@@ -64,11 +64,15 @@ function writeReports(options) {
   }
 
   var data = '';
-  var coverageRe = /__coverage__='([^;]*)';(\r\n?|\n)/gi;
+  var coverageRe = /__coverage__='([^;]*)';/gi;
+  var skippedPreviousLine = false;
   var extractCoverage = through(function(buf, enc, next) {
     data += buf;
     if (!coverageRe.test(buf.toString())) {
-      this.push(buf);
+      if (!skippedPreviousLine) this.push(buf);
+      skippedPreviousLine = false;
+    } else {
+      skippedPreviousLine = true;
     }
     next();
   }, function(next) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "lodash": "^2.4.1",
     "minimatch": "^3.0.0",
     "resolve": "^1.1.6",
+    "split": "^1.0.0",
+    "stream-combiner": "^0.2.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "lodash": "^2.4.1",
     "minimatch": "^3.0.0",
     "resolve": "^1.1.6",
-    "split": "^1.0.0",
-    "stream-combiner": "^0.2.2",
+    "split2": "^2.1.1",
+    "stream-combiner2": "^1.1.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var exec = require('child_process').exec;
 var mochify = require('mochify');
 var assert = require('assert');
 var through = require('through2');
@@ -249,4 +250,23 @@ describe('Basic', function () {
     }))
   });
 
+  it('should print full test reports when run from the command line', function (done) {
+    var testFile = './test/fixtures/fail-50.js';
+    var reporter = 'tap'
+    var firstOut;
+
+    createTestInstance(testFile, {
+      report: ['json']
+    })
+    .bundle(function () {
+      // save first output, reset the stream and compare
+      firstOut = out;
+      resetOutput();
+
+      exec('./node_modules/.bin/mochify --reporter=tap --plugin [ . ] ' + testFile, function(err, result) {
+        assert.deepEqual(firstOut, result, 'cli did not print full test report');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
I'm running a test suite against mochify. When starting to add coverage reports using `mochify-istanbul` I am facing the following issue:

When one of the tests fails I will not see the report, but simply:

```
# phantomjs:
Error: Exit 1
```

which makes it rather hard to find out what broke.

My test command looks like:

```
"mochify": "NODE_ENV=test mochify --plugin [ mochify-istanbul --report html --dir ./js_coverage --exclude '**/*.{json,toml,html,test.js}' ] --timeout=10000 --reporter=spec ./assets/scripts/test/unit/**/*.js",
```

When no tests fail, the report will be printed all at once.

This is due to the fact that this currently buffers all output in a variable and then passes it on in the `flushFunction` of the `through2` stream. Yet, this `flushFunction` will apparently never be called when one of the tests fail, resulting in the behavior above.

Instead, this PR splits the input on newlines and the checks if we are handling coverage or not.