### PR TITLE
Update lodash to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/ferlores/mochify-istanbul",
   "dependencies": {
     "istanbul": "^0.4.2",
-    "lodash": "^2.4.1",
+    "lodash": "^4.17.11",
     "minimatch": "^3.0.0",
     "resolve": "^1.1.6",
     "split2": "^2.1.1",


### PR DESCRIPTION
This removes a security warning in dependent projects:

```
┌───────────────┬────────────────────────────────────────┐
│ Low           │ Prototype Pollution                    │
├───────────────┼────────────────────────────────────────┤
│ Package       │ lodash                                 │
├───────────────┼────────────────────────────────────────┤
│ Patched in    │ >=4.17.5                               │
├───────────────┼────────────────────────────────────────┤
│ Dependency of │ mochify-istanbul [dev]                 │
├───────────────┼────────────────────────────────────────┤
│ Path          │ mochify-istanbul > lodash              │
├───────────────┼────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577 │
└───────────────┴────────────────────────────────────────┘
```

I wasn't able to install dependencies locally to even try to run the tests, hoping that travis is still able to.